### PR TITLE
Connect signup pages

### DIFF
--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -1,12 +1,25 @@
 class AddressesController < ApplicationController
 
   def new
+    @address = Address.new
   end
 
   def create
+    @address = Address.new(address_params)
+    if @address.save
+      redirect_to new_user_card_path(current_user.id), notice: 'グループを作成しました'
+    else
+      render :new
+    end
   end
 
   def show
+  end
+
+  private
+
+  def address_params
+    params.permit(:postalcode, :prefecture, :city, :number, :building, :phone_number).merge(user_id: current_user.id)
   end
 
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -51,13 +51,13 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # end
 
   # The path used after sign up.
-  # def after_sign_up_path_for(resource)
-  #   super(resource)
-  # end
+  def after_sign_up_path_for(resource)
+    telephone_authentication_user_path(current_user.id)
+  end
 
   # The path used after sign up for inactive accounts.
   def after_inactive_sign_up_path_for(resource)
-    root_path
+    telephone_authentication_user_path(current_user.id)
   end
 
   def create

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -2,12 +2,12 @@ class Address < ApplicationRecord
 
   belongs_to :user
   
-  reg_postalcode = /\A[0-9]{3}\-[0-9]{4}+\z/
+  # reg_postalcode = /\A[0-9]{3}\-[0-9]{4}+\z/
   reg_intger_10or11_characters = /\A[0-9]{10,11}+\z/
 
   validates :postalcode,
-    presence: true,
-    format: { with: reg_postalcode }
+    presence: true
+    # format: { with: reg_postalcode }
   with_options presence: true do
     validates :prefecture
     validates :city

--- a/app/views/addresses/new.html.haml
+++ b/app/views/addresses/new.html.haml
@@ -33,7 +33,7 @@
       %p.bold お名前カナ
       %p イシノモリ ショウタロウ
 
-    = form_with url: 'user_addresses_path', local: true, class: 'mi_form' do |f|
+    = form_with url: user_addresses_path(current_user.id), local: true, class: 'mi_form' do |f|
 
       .mi_form__group
         %label.bold{ for: "postalcode" } 郵便番号

--- a/app/views/cards/new.html.haml
+++ b/app/views/cards/new.html.haml
@@ -68,6 +68,7 @@
           %span.card_new_form__group__question ？
           %span カード裏面の番号とは？
 
-      = f.submit '次へ進む',class: 'card_new_form__submit_btn'
+      /= f.submit '次へ進む',class: 'card_new_form__submit_btn'
+      = link_to '次へ進む', signup_complete_users_path, class: 'card_new_form__submit_btn', data:{turbolinks: :false}
 
   =render partial: 'devise/shared/gray_footer'

--- a/app/views/users/signup_complete.html.haml
+++ b/app/views/users/signup_complete.html.haml
@@ -31,6 +31,6 @@
         %p 会員登録が完了しました。
         
       .signup_complete_group__item
-        = link_to 'メルカリを始める', 'root_path', class: 'signup_complete_group__item__link', data:{turbolinks: :false}
+        = link_to 'メルカリを始める', root_path, class: 'signup_complete_group__item__link', data:{turbolinks: :false}
 
   =render partial: 'devise/shared/gray_footer'

--- a/app/views/users/telephone_authentication.html.haml
+++ b/app/views/users/telephone_authentication.html.haml
@@ -32,7 +32,8 @@
         = f.text_field :phone_number, name: "phone_number", class: 'mi_form__group__input', placeholder: "例）09012345678"
         %p 本人確認のため、携帯電話のSMS（ショートメッセージサービス）を利用して認証を行います。
 
-      = f.submit '登録する',class: 'mi_form__submit_btn'
+      /= f.submit '登録する',class: 'mi_form__submit_btn'
+      = link_to '次へ進む', new_user_address_path(current_user.id), class: 'mi_form__submit_btn', data:{turbolinks: :false}
       %p ※電話番号は本人確認や不正利用防止のために利用します。他のユーザーに公開されることはありません。
 
     .text-right


### PR DESCRIPTION
# WHAT
addressの登録機能
ページの遷移先の指定

# WHY
新規登録画面へ全てとべて、user/addressの登録を行えるようにする